### PR TITLE
Upgrade to Stripe Java SDK 2.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
                 :url "http://www.eclipse.org/legal/epl-v10.html"}
   :description "Stripe API client in Clojure"
   :dependencies [[org.clojure/clojure    "1.7.0"]
-                 [com.stripe/stripe-java "1.40.0"]]
+                 [com.stripe/stripe-java "2.8.0"]]
   :profiles {:1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0-RC4"]]}
              :master {:dependencies [[org.clojure/clojure "1.8.0-master-SNAPSHOT"]]}

--- a/src/clojure/clojurewerkz/elephant/conversion.clj
+++ b/src/clojure/clojurewerkz/elephant/conversion.clj
@@ -3,7 +3,7 @@
    Not supposed to be used directly, not a part of the public Elephant API."
   (:import [clojure.lang IPersistentMap]
            java.util.List
-           [com.stripe.model StripeCollection StripeCollectionAPIResource
+           [com.stripe.model StripeCollection
             Account Balance BalanceTransaction Card Charge Coupon Customer Dispute
             Discount Fee Money NextRecurringCharge Subscription Refund InvoiceItem
             Invoice DeletedCustomer DeletedCoupon DeletedInvoiceItem]))
@@ -118,7 +118,7 @@
    :__origin__ r})
 
 (defn refunds-coll->seq
-  [^StripeCollectionAPIResource xs]
+  [^StripeCollection xs]
   (map refund->map (.getData xs)))
 
 (defn ^IPersistentMap dispute->map
@@ -148,7 +148,7 @@
    :paid?      (.getPaid c)
    :refunded?       (.getRefunded c)
    :amount-refunded (.getAmountRefunded c)
-   :refunds    (doall (map refund->map (if-let [^StripeCollectionAPIResource xs (.getRefunds c)]
+   :refunds    (doall (map refund->map (if-let [^StripeCollection xs (.getRefunds c)]
                                          (.getData xs)
                                          [])))
    :captured?  (.getCaptured c)
@@ -200,7 +200,7 @@
    :__origin__             s})
 
 (defn subscriptions-coll->seq
-  [^StripeCollectionAPIResource xs]
+  [^StripeCollection xs]
   (map subscription->map (.getData xs)))
 
 (defn ^IPersistentMap coupon->map
@@ -250,7 +250,7 @@
 
 (defn ^IPersistentMap customer->map
   [^Customer c]
-  (let [sources (doall (map card->map (if-let [^StripeCollectionAPIResource xs (.getSources c)]
+  (let [sources (doall (map card->map (if-let [^StripeCollection xs (.getSources c)]
                                         (.getData xs)
                                         [])))]
     {:id             (.getId c)
@@ -264,7 +264,7 @@
                               (next-recurring-charge->map nrc))
      :sources         sources
      :cards           sources
-     :subscriptions   (doall (map subscription->map (if-let [^StripeCollectionAPIResource xs (.getSubscriptions c)]
+     :subscriptions   (doall (map subscription->map (if-let [^StripeCollection xs (.getSubscriptions c)]
                                                       (.getData xs)
                                                       [])))
      ;; TODO: convert to UTC date with clj-time

--- a/test/clojurewerkz/elephant/integration_test.clj
+++ b/test/clojurewerkz/elephant/integration_test.clj
@@ -21,7 +21,7 @@
 
 (let [cc {"number"    "4242424242424242"
           "exp_month" 12
-          "exp_year"  2015
+          "exp_year"  2016
           "cvc"       "123"
           "name"      "J Bindings Cardholder"
           "address_line1"   "140 2nd Street"
@@ -44,7 +44,7 @@
         ;; debit card
         dc  {"number"    "4000056655665556"
              "exp_month" 12
-             "exp_year"  2015
+             "exp_year"  2016
              "cvc"       "123"
              "name"            "J Bindings Debitholder"
              "address_line1"   "140 2nd Street"
@@ -201,7 +201,7 @@
     (deftest test-charge-with-invalid-card
       (let [m (assoc chg "card" {"number" "4242424242424241"
                                  "exp_month" 12
-                                 "exp_year"  2015})]
+                                 "exp_year"  2016})]
         (is (thrown? com.stripe.exception.CardException
                      (ech/create m)))))
 


### PR DESCRIPTION
Update code to match API changes and fix tests that are based on cc expiry.
